### PR TITLE
Add drone imagery column to farm dashboard

### DIFF
--- a/data/farms.js
+++ b/data/farms.js
@@ -11,21 +11,39 @@ export const farms = [
         name: 'North Block',
         moisture: 'Optimal',
         fertility: 'Stable',
-        recommendation: 'Maintain irrigation schedule at 0.8"'
+        recommendation: 'Maintain irrigation schedule at 0.8"',
+        droneImagery: {
+          status: 'Ready',
+          image: '/drone-almond-north.svg',
+          summary: 'Canopy vigor trending high along the northwest rows.',
+          recommendation: 'Hold irrigation reductions at 5% to balance canopy growth.'
+        }
       },
       {
         id: 'zone-2',
         name: 'Central Block',
         moisture: 'Low',
         fertility: 'Low Nitrogen',
-        recommendation: 'Irrigate 1.2" and supplement nitrogen'
+        recommendation: 'Irrigate 1.2" and supplement nitrogen',
+        droneImagery: {
+          status: 'Ready',
+          image: '/drone-almond-central.svg',
+          summary: 'Thermal map highlights dry streaks along the center pivot.',
+          recommendation: 'Run targeted irrigation on rows 6-12 and apply foliar nitrogen after sunset.'
+        }
       },
       {
         id: 'zone-3',
         name: 'South Block',
         moisture: 'Critical',
         fertility: 'Very Low Potassium',
-        recommendation: 'Irrigate 1.5" and apply potassium foliar feed'
+        recommendation: 'Irrigate 1.5" and apply potassium foliar feed',
+        droneImagery: {
+          status: 'Ready',
+          image: '/drone-almond-south.svg',
+          summary: 'Heat stress concentrated near the southern ridge.',
+          recommendation: 'Deploy shade cloth mid-day and schedule 1.5" irrigation overnight.'
+        }
       }
     ]
   },
@@ -41,14 +59,26 @@ export const farms = [
         name: 'Cabernet Block',
         moisture: 'Moderate',
         fertility: 'Balanced',
-        recommendation: 'Monitor soil tension; no action required'
+        recommendation: 'Monitor soil tension; no action required',
+        droneImagery: {
+          status: 'Ready',
+          image: '/drone-valley-cabernet.svg',
+          summary: 'NDVI uniformity shows consistent berry set across canopy.',
+          recommendation: 'Continue standard canopy management schedule.'
+        }
       },
       {
         id: 'zone-2',
         name: 'Merlot Block',
         moisture: 'Low',
         fertility: 'Low Magnesium',
-        recommendation: 'Initiate drip cycle and apply Mg foliar spray'
+        recommendation: 'Initiate drip cycle and apply Mg foliar spray',
+        droneImagery: {
+          status: 'Ready',
+          image: '/drone-valley-merlot.svg',
+          summary: 'Low vigor lanes detected on the east-facing slope.',
+          recommendation: 'Spot fertigation rows 4-7 on the east slope and boost irrigation by 0.3".'
+        }
       }
     ]
   },
@@ -64,21 +94,39 @@ export const farms = [
         name: 'Honeycrisp Section',
         moisture: 'High',
         fertility: 'Stable',
-        recommendation: 'Pause irrigation for 24h'
+        recommendation: 'Pause irrigation for 24h',
+        droneImagery: {
+          status: 'Ready',
+          image: '/drone-sunrise-honeycrisp.svg',
+          summary: 'Dense canopy indicates strong fruit set with minor shading.',
+          recommendation: 'Delay irrigation for 24 hours and thin clusters along rows 2-3.'
+        }
       },
       {
         id: 'zone-2',
         name: 'Gala Section',
         moisture: 'Optimal',
         fertility: 'Low Phosphorus',
-        recommendation: 'Apply phosphorus-rich fertigation'
+        recommendation: 'Apply phosphorus-rich fertigation',
+        droneImagery: {
+          status: 'Ready',
+          image: '/drone-sunrise-gala.svg',
+          summary: 'Balanced canopy with light nutrient shading near the northeast lane.',
+          recommendation: 'Apply phosphorus-rich fertigation this week to maintain canopy balance.'
+        }
       },
       {
         id: 'zone-3',
         name: 'Fuji Section',
         moisture: 'Moderate',
         fertility: 'Balanced',
-        recommendation: 'Maintain current irrigation pattern'
+        recommendation: 'Maintain current irrigation pattern',
+        droneImagery: {
+          status: 'Ready',
+          image: '/drone-sunrise-fuji.svg',
+          summary: 'Moisture gradients improving near the drainage channel.',
+          recommendation: 'Maintain irrigation schedule and monitor low spots after rainfall.'
+        }
       }
     ]
   }

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -6,6 +6,13 @@ import { farms } from '../data/farms';
 
 const REQUIRED_SOIL_HEADERS = ['zone', 'moisture', 'fertility', 'recommendation'];
 
+const DEFAULT_DRONE_PLACEHOLDER = {
+  status: 'Awaiting upload',
+  image: '/drone-placeholder.svg',
+  summary: 'Drone imagery has not been processed for this zone yet.',
+  recommendation: 'Upload the latest drone imagery to receive AI-assisted insights.'
+};
+
 const parseSoilCsv = (csvText) => {
   const lines = csvText
     .split(/\r?\n/)
@@ -36,7 +43,8 @@ const parseSoilCsv = (csvText) => {
       name: zoneName,
       moisture: cells[headerIndexes[1]] || 'Unknown',
       fertility: cells[headerIndexes[2]] || 'Unknown',
-      recommendation: cells[headerIndexes[3]] || 'No recommendation provided'
+      recommendation: cells[headerIndexes[3]] || 'No recommendation provided',
+      droneImagery: { ...DEFAULT_DRONE_PLACEHOLDER }
     };
   });
 
@@ -163,16 +171,35 @@ export default function Dashboard() {
         </section>
 
         <section className="zones-grid">
-          {displayFarm.zones.map((zone) => (
-            <article className="card zone-card" key={zone.id}>
-              <h3>{zone.name}</h3>
-              <div className="zone-details">
-                <p><span>Soil Moisture</span><strong>{zone.moisture}</strong></p>
-                <p><span>Fertility</span><strong>{zone.fertility}</strong></p>
-                <p><span>AI Recommendation</span><strong>{zone.recommendation}</strong></p>
-              </div>
-            </article>
-          ))}
+          {displayFarm.zones.map((zone) => {
+            const droneImagery = { ...DEFAULT_DRONE_PLACEHOLDER, ...(zone.droneImagery || {}) };
+
+            return (
+              <article className="card zone-card" key={zone.id}>
+                <h3>{zone.name}</h3>
+                <div className="zone-layout">
+                  <div className="zone-details">
+                    <p><span>Soil Moisture</span><strong>{zone.moisture}</strong></p>
+                    <p><span>Fertility</span><strong>{zone.fertility}</strong></p>
+                    <p><span>AI Recommendation</span><strong>{zone.recommendation}</strong></p>
+                  </div>
+                  <div className="zone-drone">
+                    <div className="zone-drone-header">
+                      <h4>Drone Imagery Results</h4>
+                      <span className={`drone-status drone-status-${droneImagery.status.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>
+                        {droneImagery.status}
+                      </span>
+                    </div>
+                    <div className="drone-image-wrapper">
+                      <img src={droneImagery.image} alt={`Drone imagery for ${zone.name}`} />
+                    </div>
+                    <p className="drone-summary">{droneImagery.summary}</p>
+                    <p className="drone-recommendation"><strong>Recommendation:</strong> {droneImagery.recommendation}</p>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
         </section>
 
         <section className="card actions-card">

--- a/public/drone-almond-central.svg
+++ b/public/drone-almond-central.svg
@@ -1,0 +1,14 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="10%" y1="0%" x2="90%" y2="100%">
+      <stop offset="0%" stop-color="#fff4d6" />
+      <stop offset="100%" stop-color="#f1c27d" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="24" fill="url(#grad)" />
+  <path d="M90 210C150 190 180 210 230 190C280 170 330 190 390 170" stroke="#b07720" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.9" />
+  <circle cx="150" cy="130" r="36" fill="#b07720" opacity="0.16" />
+  <circle cx="310" cy="110" r="30" fill="#b07720" opacity="0.22" />
+  <text x="50%" y="54%" text-anchor="middle" fill="#714c17" font-size="26" font-weight="700" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Central Block</text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#714c17" font-size="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.85">Water stress patches mapped</text>
+</svg>

--- a/public/drone-almond-north.svg
+++ b/public/drone-almond-north.svg
@@ -1,0 +1,14 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="15%" y1="0%" x2="85%" y2="100%">
+      <stop offset="0%" stop-color="#dff8e7" />
+      <stop offset="100%" stop-color="#8ad1a0" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="24" fill="url(#grad)" />
+  <path d="M70 220C115 205 170 180 230 210C290 240 345 200 390 175" stroke="#2d7f5f" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.85" />
+  <circle cx="180" cy="140" r="40" fill="#2d7f5f" opacity="0.22" />
+  <circle cx="320" cy="120" r="28" fill="#2d7f5f" opacity="0.18" />
+  <text x="50%" y="54%" text-anchor="middle" fill="#114734" font-size="26" font-weight="700" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">North Block</text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#114734" font-size="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.8">Canopy vigor trending high</text>
+</svg>

--- a/public/drone-almond-south.svg
+++ b/public/drone-almond-south.svg
@@ -1,0 +1,14 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="15%" x2="100%" y2="85%">
+      <stop offset="0%" stop-color="#ffe0e5" />
+      <stop offset="100%" stop-color="#ff8ba0" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="24" fill="url(#grad)" />
+  <path d="M80 230C140 190 220 210 260 190C300 170 340 150 410 180" stroke="#aa314f" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.9" />
+  <circle cx="190" cy="140" r="34" fill="#aa314f" opacity="0.2" />
+  <circle cx="300" cy="110" r="28" fill="#aa314f" opacity="0.18" />
+  <text x="50%" y="54%" text-anchor="middle" fill="#6e1f33" font-size="26" font-weight="700" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">South Block</text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#6e1f33" font-size="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.85">Heat stress zones flagged</text>
+</svg>

--- a/public/drone-placeholder.svg
+++ b/public/drone-placeholder.svg
@@ -1,0 +1,16 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#d7f2ff" />
+      <stop offset="100%" stop-color="#9ed8ff" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="24" fill="url(#grad)" />
+  <g opacity="0.9">
+    <path d="M80 220C120 180 180 160 240 200C300 240 360 220 400 180" stroke="#0a6a73" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    <circle cx="160" cy="150" r="26" fill="#0a6a73" opacity="0.18" />
+    <circle cx="320" cy="120" r="34" fill="#0a6a73" opacity="0.22" />
+  </g>
+  <text x="50%" y="52%" text-anchor="middle" fill="#0a3142" font-size="24" font-weight="600" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Drone imagery pending</text>
+  <text x="50%" y="68%" text-anchor="middle" fill="#0a3142" font-size="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.8">Upload data to unlock insights</text>
+</svg>

--- a/public/drone-sunrise-fuji.svg
+++ b/public/drone-sunrise-fuji.svg
@@ -1,0 +1,14 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="10%" y1="0%" x2="90%" y2="100%">
+      <stop offset="0%" stop-color="#e7fdea" />
+      <stop offset="100%" stop-color="#66d189" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="24" fill="url(#grad)" />
+  <path d="M70 220C130 205 210 225 260 205C310 185 340 175 400 195" stroke="#1f7c43" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.88" />
+  <circle cx="190" cy="140" r="34" fill="#1f7c43" opacity="0.2" />
+  <circle cx="300" cy="120" r="28" fill="#1f7c43" opacity="0.18" />
+  <text x="50%" y="54%" text-anchor="middle" fill="#12502a" font-size="26" font-weight="700" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Fuji Section</text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#12502a" font-size="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.82">Moisture improving</text>
+</svg>

--- a/public/drone-sunrise-gala.svg
+++ b/public/drone-sunrise-gala.svg
@@ -1,0 +1,14 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="15%" x2="100%" y2="85%">
+      <stop offset="0%" stop-color="#e4f9ff" />
+      <stop offset="100%" stop-color="#6ec1ff" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="24" fill="url(#grad)" />
+  <path d="M80 225C140 205 200 220 250 205C300 190 350 175 400 185" stroke="#1f6da8" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.88" />
+  <circle cx="190" cy="140" r="34" fill="#1f6da8" opacity="0.22" />
+  <circle cx="300" cy="120" r="28" fill="#1f6da8" opacity="0.18" />
+  <text x="50%" y="54%" text-anchor="middle" fill="#134265" font-size="26" font-weight="700" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Gala Section</text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#134265" font-size="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.82">Nutrients balanced</text>
+</svg>

--- a/public/drone-sunrise-honeycrisp.svg
+++ b/public/drone-sunrise-honeycrisp.svg
@@ -1,0 +1,14 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="5%" y1="0%" x2="95%" y2="100%">
+      <stop offset="0%" stop-color="#fff0d9" />
+      <stop offset="100%" stop-color="#ffb25b" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="24" fill="url(#grad)" />
+  <path d="M70 225C130 195 210 215 260 195C310 175 340 165 400 185" stroke="#c86a1f" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.9" />
+  <circle cx="190" cy="140" r="34" fill="#c86a1f" opacity="0.22" />
+  <circle cx="300" cy="120" r="28" fill="#c86a1f" opacity="0.18" />
+  <text x="50%" y="54%" text-anchor="middle" fill="#7b3d10" font-size="26" font-weight="700" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Honeycrisp</text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#7b3d10" font-size="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.85">High canopy density</text>
+</svg>

--- a/public/drone-valley-cabernet.svg
+++ b/public/drone-valley-cabernet.svg
@@ -1,0 +1,14 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="20%" x2="100%" y2="80%">
+      <stop offset="0%" stop-color="#f0e0ff" />
+      <stop offset="100%" stop-color="#a87be5" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="24" fill="url(#grad)" />
+  <path d="M70 220C150 200 190 230 250 210C310 190 340 170 410 195" stroke="#5e2c99" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.88" />
+  <circle cx="170" cy="140" r="36" fill="#5e2c99" opacity="0.2" />
+  <circle cx="320" cy="120" r="30" fill="#5e2c99" opacity="0.18" />
+  <text x="50%" y="54%" text-anchor="middle" fill="#341a57" font-size="26" font-weight="700" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Cabernet Block</text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#341a57" font-size="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.84">Berry set uniform</text>
+</svg>

--- a/public/drone-valley-merlot.svg
+++ b/public/drone-valley-merlot.svg
@@ -1,0 +1,14 @@
+<svg width="480" height="320" viewBox="0 0 480 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="10%" y1="0%" x2="90%" y2="100%">
+      <stop offset="0%" stop-color="#ffe9f0" />
+      <stop offset="100%" stop-color="#f07fb5" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="320" rx="24" fill="url(#grad)" />
+  <path d="M90 230C150 190 200 215 250 200C300 185 340 165 390 175" stroke="#a8346a" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.9" />
+  <circle cx="190" cy="140" r="32" fill="#a8346a" opacity="0.22" />
+  <circle cx="300" cy="110" r="26" fill="#a8346a" opacity="0.18" />
+  <text x="50%" y="54%" text-anchor="middle" fill="#681d3f" font-size="26" font-weight="700" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Merlot Block</text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#681d3f" font-size="18" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" opacity="0.82">Low vigor rows detected</text>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -164,6 +164,12 @@ input[type="file"]:focus {
   margin-bottom: 18px;
 }
 
+.zone-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 20px;
+}
+
 .zone-details p {
   display: flex;
   justify-content: space-between;
@@ -179,6 +185,77 @@ input[type="file"]:focus {
 
 .zone-details strong {
   color: #06706f;
+}
+
+.zone-drone {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.zone-drone-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.zone-drone h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #054b5a;
+}
+
+.drone-status {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(6, 61, 77, 0.08);
+  color: #0d5664;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.drone-status-ready {
+  background: rgba(15, 157, 88, 0.18);
+  color: #117a3b;
+}
+
+.drone-status-awaiting-upload {
+  background: rgba(148, 163, 184, 0.2);
+  color: #475569;
+}
+
+.drone-status-processing {
+  background: rgba(253, 200, 47, 0.2);
+  color: #b7791f;
+}
+
+.drone-image-wrapper {
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(219, 246, 255, 0.7), rgba(233, 255, 245, 0.7));
+  box-shadow: inset 0 0 0 1px rgba(6, 61, 77, 0.06);
+}
+
+.drone-image-wrapper img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.drone-summary {
+  margin: 0;
+  color: #0a5466;
+  font-weight: 500;
+}
+
+.drone-recommendation {
+  margin: 0;
+  color: #054b5a;
+  font-weight: 600;
 }
 
 .actions-card {
@@ -221,5 +298,16 @@ button:hover {
 
   .farm-highlights {
     grid-template-columns: 1fr;
+  }
+
+  .zone-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 900px) {
+  .zone-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+    align-items: start;
   }
 }


### PR DESCRIPTION
## Summary
- add drone imagery metadata and illustrative assets for each farm zone
- update the dashboard zones to surface drone imagery results alongside soil metrics
- style the new drone insights column and provide a placeholder when imagery is pending

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc61f77c14832da0bac6ff0b82a9f6